### PR TITLE
Chum integration for the Qtwayland 5.6 branch

### DIFF
--- a/rpm/qxcompositor.changes.in
+++ b/rpm/qxcompositor.changes.in
@@ -8,6 +8,11 @@
 # * date Author's Name <author's email> version-release
 # - Summary of changes
 
+* Thu Aug 19 2022 kabouik
+- Updated description and license for Chum repository
+- Bumped version to avoid dep resolution issues
+- Segregated packages so that devices < 4.2.0 with qtwayland-5.4 can still install qxcompositor before it was refactored to qtwayland-5.6, and devices >= 4.2.0 use the refactored qxcompositor
+
 * Sun Apr 13 2014 Jack Tar <jack.tar@example.com> 0.0.4-1
 - Synchronize clipboard
 

--- a/rpm/qxcompositor.spec
+++ b/rpm/qxcompositor.spec
@@ -4,13 +4,18 @@ Name:       qxcompositor
 %{!?qtc_qmake5:%define qtc_qmake5 %qmake5}
 %{!?qtc_make:%define qtc_make make}
 %{?qtc_builddir:%define _builddir %qtc_builddir}
-Summary:    My Sailfish OS Application
-Version:    0.0.5
-Release:    1
+Summary:    Qml compositor for running Xwayland on Sailfish
+Version:    0.0.6
+Release:    0
 Group:      Qt/Qt
-License:    LICENSE
-URL:        http://example.org/
+License:    BSD-3-Clause
+URL:        https://github.com/elros34/qxcompositor
 Source0:    %{name}-%{version}.tar.bz2
+
+# Segregate the SFOS releases range covered by each release branch (branch qtwayland-5.6 for SFOS >= 4.2.0):
+Requires: sailfish-version >= 4.2.0
+# Requires: sailfish-version < X.Y.Z # Not yet known
+
 Requires:   sailfishsilica-qt5 >= 0.10.9
 BuildRequires:  pkgconfig(sailfishapp) >= 1.0.2
 BuildRequires:  pkgconfig(Qt5Core)
@@ -21,7 +26,22 @@ BuildRequires:  pkgconfig(mlite5)
 
 
 %description
-Qml compositor for running Xwayland on sailfish
+Qml compositor for running Xwayland on Sailfish
+# This description section includes metadata for SailfishOS:Chum, see
+# https://github.com/sailfishos-chum/main/blob/main/Metadata.md
+%if "%{?vendor}" == "chum"
+PackageName: qxcompositor
+Type: desktop-application
+DeveloperName: elros34
+Categories:
+ - Development
+ - Utilities
+ - Other
+Custom:
+  Repo: https://github.com/elros34/qxcompositor
+Url:
+  Homepage: https://github.com/elros34/qxcompositor
+%endif
 
 
 %prep


### PR DESCRIPTION
When/if this is merged, I can point OBS to here instead of the fork, and resubmit to Chum.

Now I am not sure how to make it so devices that still have the older qtwayland can have qxcompositor (from master) too. I don't know if Chum allows having multiple versions of the same program at the same time, to offer one version for old and one for new devices…

Thanks for this awesome work on chroot/compositor stuff, this really changed everything to my SFOS experience.